### PR TITLE
Throw error if DID Document has empty 'object' property.

### DIFF
--- a/lib/methods/veres-one-client.js
+++ b/lib/methods/veres-one-client.js
@@ -88,6 +88,11 @@ class VeresOneClient {
     };
 
     const didDoc = body.object;
+
+    if(!didDoc) {
+      throw new Error('Fetched DID Document has empty body/"object" property');
+    }
+
     const context = didDoc['@context'];
 
     if(!hashFragment) {

--- a/tests/veres-one-client.spec.js
+++ b/tests/veres-one-client.spec.js
@@ -17,7 +17,7 @@ const TEST_DID_RESULT = require('./dids/genesis.testnet.did.json');
 const LEDGER_AGENTS_DOC = require('./dids/ledger-agents.json');
 const ACCELERATOR_RESPONSE = require('./dids/accelerator-response.json');
 
-describe('did methods', () => {
+describe('web ledger client', () => {
   let client;
 
   beforeEach(() => {


### PR DESCRIPTION
Fixes https://github.com/digitalbazaar/did-io/issues/26.