### PR TITLE
Add check for Error.captureStackTrace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # web-ledger-client ChangeLog
 
+## 3.3.1 -
+
+### Added
+- Added a check to ensure `Error.captureStackTrace` is a function before using it.
+
 ## 3.3.0 - 2019-10-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.3.1 -
 
-### Added
+### Fixed
 - Added a check to ensure `Error.captureStackTrace` is a function before using it.
 
 ## 3.3.0 - 2019-10-24

--- a/lib/WebLedgerClientError.js
+++ b/lib/WebLedgerClientError.js
@@ -8,6 +8,9 @@ module.exports = class WebLedgerClientError extends Error {
     super(message);
     this.name = name;
     this.details = details;
-    Error.captureStackTrace(this, this.constructor);
+    // this throws in the browser
+    if(typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor);
+    }
   }
 };

--- a/lib/WebLedgerClientError.js
+++ b/lib/WebLedgerClientError.js
@@ -8,7 +8,7 @@ module.exports = class WebLedgerClientError extends Error {
     super(message);
     this.name = name;
     this.details = details;
-    // this throws in the browser
+    // captureStackTrace is node only
     if(typeof Error.captureStackTrace === 'function') {
       Error.captureStackTrace(this, this.constructor);
     }


### PR DESCRIPTION
This fixes a small issue, this library assumes that [`Error.captureStackTrace`](https://nodejs.org/api/errors.html#errors_error_capturestacktrace_targetobject_constructoropt) is in all `Error` objects. Most browsers do not support `Error.captureStackTrace`

https://caniuse.com/?search=Error.captureStackTrace
https://caniuse.com/?search=captureStackTrace

in fact no browser seems to support it yet.