### PR TITLE
Remove api sauce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - API `getRecord` does not append a `/` before query string any more.
 - Updated tests for `getRecord` to no longer expect query string after `/`.
+- Network errors are now HTTPErrors and not axios errors.
 
 ## 3.4.1 - 2021-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 3.4.2 - TBD
 
 ### Removed
-- `apisauce` in favor of `@digitalbazaar/http-client` this is part of a move away from axios.
+- Replaced `apisauce` with `@digitalbazaar/http-client`.
 
 ### Changed
 - Switched the API `getRecord` from `apisauce` to `@digitalbazaar/httpClient`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Changed
 - Switched the API `getRecord` from `apisauce` to `@digitalbazaar/httpClient`.
 - API `getRecord` does not append a `/` before query string any more.
-- Updated tests dor `getRecord`	to no longer expect query string after `/`.
+- Updated tests for `getRecord` to no longer expect query string after `/`.
 - Switched the API `getDocument` from `apisauce` to `@digitalbazaar/httpClient`.
 - Switched the API `sendDocument` from `apisauce` to `@digitalbazaar/httpClient`.
 - Switched the API `getAgents` from `apisauce` to `@digitalbazaar/httpClient`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # web-ledger-client ChangeLog
 
+### 3.4.2 - TBD
+
+### Removed
+- `apisauce` in favor of `@digitalbazaar/http-client` this is part of a move away from axios.
+
+### Changed
+- Switched the API `getRecord` from `apisauce` to `@digitalbazaar/httpClient`.
+- API `getRecord` does not append a `/` before query string any more.
+- Updated tests dor `getRecord`	to no longer expect query string after `/`.
+- Switched the API `getDocument` from `apisauce` to `@digitalbazaar/httpClient`.
+- Switched the API `sendDocument` from `apisauce` to `@digitalbazaar/httpClient`.
+- Switched the API `getAgents` from `apisauce` to `@digitalbazaar/httpClient`.
+
 ## 3.4.1 - 2021-03-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,13 @@
 # web-ledger-client ChangeLog
 
-### 3.4.2 - TBD
+### 4.0.0 - TBD
 
 ### Removed
-- Replaced `apisauce` with `@digitalbazaar/http-client`.
+- **BREAKING**: Replaced `apisauce` with `@digitalbazaar/http-client`.
 
 ### Changed
-- Switched the API `getRecord` from `apisauce` to `@digitalbazaar/httpClient`.
 - API `getRecord` does not append a `/` before query string any more.
 - Updated tests for `getRecord` to no longer expect query string after `/`.
-- Switched the API `getDocument` from `apisauce` to `@digitalbazaar/httpClient`.
-- Switched the API `sendDocument` from `apisauce` to `@digitalbazaar/httpClient`.
-- Switched the API `getAgents` from `apisauce` to `@digitalbazaar/httpClient`.
 
 ## 3.4.1 - 2021-03-16
 

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -6,7 +6,6 @@
 const _get = require('lodash.get');
 const constants = require('./constants');
 const {httpClient, DEFAULT_HEADERS} = require('@digitalbazaar/http-client');
-const {create} = require('apisauce');
 const WebLedgerClientError = require('./WebLedgerClientError');
 
 /**

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -303,8 +303,7 @@ class WebLedgerClient {
   async getAgents({headers = {}} = {}) {
     const baseURL = `https://${this.hostname}`;
     try {
-      const {data} = await httpClient.get('ledger-agents', {
-        prefixUrl: baseURL,
+      const {data} = await httpClient.get(`${baseUrl}/ledger-agents`, {
         headers: {...DEFAULT_HEADERS, ...headers},
         agent: this.httpsAgent,
         timeout: this.timeout

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -305,14 +305,19 @@ class WebLedgerClient {
    */
   async getAgents({headers = {}} = {}) {
     const baseURL = `https://${this.hostname}`;
-    const requestHeaders = Object.assign(
-      {}, constants.DEFAULT_HEADERS, headers);
-    const agentsApi =
-      create({baseURL, httpsAgent: this.httpsAgent, timeout: this.timeout});
-    const response = await agentsApi.get('/ledger-agents', {}, {
-      headers: requestHeaders
-    });
-    if(response.problem) {
+    try {
+      const {data} = await httpClient.get('ledger-agents', {
+        prefixUrl: baseURL,
+        headers: {...DEFAULT_HEADERS, ...headers},
+        agent: this.httpsAgent,
+        timeout: this.timeout
+      });
+      return data.ledgerAgent;
+    } catch(e) {
+      const {response} = e;
+      if(!response) {
+        throw e;
+      }
       if(response.status === 404) {
         throw new WebLedgerClientError(
           'Record not found.', 'NotFoundError',
@@ -320,18 +325,14 @@ class WebLedgerClient {
       }
       const error = new WebLedgerClientError(
         'Error retrieving record.', 'NetworkError');
-      if(response.problem === 'CLIENT_ERROR') {
-        error.details = {
-          baseURL, error: response.data, status: response.status
-        };
-      } else {
-        error.details = {
-          baseURL, error: response.originalError, status: response.status
-        };
+      error.details = {
+        baseURL, error: response.originalError, status: response.status
+      };
+      if(response.status >= 400 && response.status < 500) {
+        error.details.error = e.data || response.data || e;
       }
       throw error;
     }
-    return response.data.ledgerAgent;
   }
 
   /**

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -66,7 +66,6 @@ class WebLedgerClient {
     let body = {};
     try {
       const response = await httpClient.post(baseURL, {
-        headers: DEFAULT_HEADERS,
         searchParams: `?id=${encodeURIComponent(id)}`,
         // send an empty body
         json: {},

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -136,6 +136,7 @@ class WebLedgerClient {
       return response.data;
     } catch(e) {
       const {response} = e;
+      // do not hide client side errors
       if(!response) {
         throw e;
       }
@@ -145,6 +146,8 @@ class WebLedgerClient {
         baseURL, error: e, service,
         status: response.status
       };
+      // if we get an error in the 400 range add the response.data
+      // to the error if present
       if(response.status >= 400 && response.status < 500) {
         error.details.error = response.data || e;
       }

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -5,7 +5,7 @@
 
 const _get = require('lodash.get');
 const constants = require('./constants');
-const {httpClient} = require('@digitalbazaar/http-client');
+const {httpClient, DEFAULT_HEADERS} = require('@digitalbazaar/http-client');
 const {create} = require('apisauce');
 const WebLedgerClientError = require('./WebLedgerClientError');
 
@@ -131,10 +131,9 @@ class WebLedgerClient {
         prefixUrl: baseURL,
         httpsAgent: this.httpsAgent,
         timeout: this.timeout,
-        headers: {...constants.DEFAULT_HEADERS, ...headers}
+        headers: {...DEFAULT_HEADERS, ...headers}
       });
-      const data = await response.json();
-      return data;
+      return response.data;
     } catch(e) {
       const {response} = e;
       if(!response) {

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -303,7 +303,7 @@ class WebLedgerClient {
   async getAgents({headers = {}} = {}) {
     const baseURL = `https://${this.hostname}`;
     try {
-      const {data} = await httpClient.get(`${baseUrl}/ledger-agents`, {
+      const {data} = await httpClient.get(`${baseURL}/ledger-agents`, {
         headers: {...DEFAULT_HEADERS, ...headers},
         agent: this.httpsAgent,
         timeout: this.timeout

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -261,7 +261,7 @@ class WebLedgerClient {
         json: document,
         headers: {...DEFAULT_HEADERS, ...headers}
       });
-      return response.data;
+      return response.data || null;
     } catch(e) {
       const {response} = e;
       if(!response) {

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -62,17 +62,25 @@ class WebLedgerClient {
 
     const ledgerAgent = await this.getAgent();
     const baseURL = ledgerAgent.service.ledgerQueryService;
-    const queryServiceApi =
-      create({baseURL, httpsAgent: this.httpsAgent, timeout: this.timeout});
 
     this.logger.log(`Retrieving Record [ledger: ${this.hostname}]:`, id);
-
-    const response = await queryServiceApi.post(
-      `?id=${encodeURIComponent(id)}`, {}, {
-        headers: constants.DEFAULT_HEADERS
+    let body = {};
+    try {
+      const response = await httpClient.post(baseURL, {
+        headers: DEFAULT_HEADERS,
+        searchParams: `?id=${encodeURIComponent(id)}`,
+        // send an empty body
+        json: {},
+        agent: this.httpsAgent,
+        timeout: this.timeout
       });
-
-    if(response.problem) {
+      body = response.data;
+    } catch(e) {
+console.log(e);
+      const {response} = e;
+      if(!response) {
+        throw e;
+      }
       if(response.status === 404) {
         throw new WebLedgerClientError(
           'Record not found.', 'NotFoundError',
@@ -80,18 +88,15 @@ class WebLedgerClient {
       }
       const error = new WebLedgerClientError(
         'Error retrieving record.', 'NetworkError');
-      if(response.problem === 'CLIENT_ERROR') {
-        error.details = {
-          baseURL, id, error: response.data, status: response.status
-        };
-      } else {
-        error.details = {
-          baseURL, id, error: response.originalError, status: response.status
-        };
+      error.details = {
+        baseURL, id, error: e, status: response.status
+      };
+      // errors in the 400 range can have response.data
+      if(response.status >= 400 && response.status < 500) {
+        error.details.error = response.data || e;
       }
       throw error;
     }
-    const body = response.data;
 
     const result = {
       found: true,

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -5,6 +5,7 @@
 
 const _get = require('lodash.get');
 const constants = require('./constants');
+const {httpClient} = require('@digitalbazaar/http-client');
 const {create} = require('apisauce');
 const WebLedgerClientError = require('./WebLedgerClientError');
 
@@ -125,29 +126,31 @@ class WebLedgerClient {
    */
   async getDocument({headers = {}, service}) {
     const baseURL = await this.getServiceEndpoint({serviceId: service});
-    const serviceApi =
-      create({baseURL, httpsAgent: this.httpsAgent, timeout: this.timeout});
-    const requestHeaders = Object.assign(
-      {}, constants.DEFAULT_HEADERS, headers);
-    const response = await serviceApi.get('/', {}, {
-      headers: requestHeaders
-    });
-    if(response.problem) {
+    try {
+      const response = await httpClient.get('', {
+        prefixUrl: baseURL,
+        httpsAgent: this.httpsAgent,
+        timeout: this.timeout,
+        headers: {...constants.DEFAULT_HEADERS, ...headers}
+      });
+      const data = await response.json();
+      return data;
+    } catch(e) {
+      const {response} = e;
+      if(!response) {
+        throw e;
+      }
       const error = new WebLedgerClientError(
         'Error retrieving document.', 'NetworkError');
-      if(response.problem === 'CLIENT_ERROR') {
-        error.details = {
-          baseURL, error: response.data, service, status: response.status
-        };
-      } else {
-        error.details = {
-          baseURL, error: response.originalError, service,
-          status: response.status
-        };
+      error.details = {
+        baseURL, error: e, service,
+        status: response.status
+      };
+      if(response.status >= 400 && response.status < 500) {
+        error.details.error = response.data || e;
       }
       throw error;
     }
-    return response.data;
   }
 
   /**

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -104,7 +104,8 @@ class WebLedgerClient {
       meta: body.meta
     };
 
-    const {record} = body;
+    // if body is undefined record will be undefined
+    const {record} = body || {};
 
     if(!record) {
       throw new WebLedgerClientError(

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -63,7 +63,7 @@ class WebLedgerClient {
     const baseURL = ledgerAgent.service.ledgerQueryService;
 
     this.logger.log(`Retrieving Record [ledger: ${this.hostname}]:`, id);
-    let body = {};
+    let body;
     try {
       const response = await httpClient.post(baseURL, {
         searchParams: `?id=${encodeURIComponent(id)}`,

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -131,8 +131,7 @@ class WebLedgerClient {
   async getDocument({headers = {}, service}) {
     const baseURL = await this.getServiceEndpoint({serviceId: service});
     try {
-      const response = await httpClient.get('', {
-        prefixUrl: baseURL,
+      const response = await httpClient.get(baseURL, {
         agent: this.httpsAgent,
         timeout: this.timeout,
         headers: {...DEFAULT_HEADERS, ...headers}
@@ -253,8 +252,7 @@ class WebLedgerClient {
     }
     const baseURL = this.ledgerAgent.service[service];
     try {
-      const response = await httpClient.post('', {
-        prefixUrl: baseURL,
+      const response = await httpClient.post(baseURL, {
         agent: this.httpsAgent,
         timeout: this.timeout,
         json: document,

--- a/lib/WebLedgerClient.js
+++ b/lib/WebLedgerClient.js
@@ -76,7 +76,6 @@ class WebLedgerClient {
       });
       body = response.data;
     } catch(e) {
-console.log(e);
       const {response} = e;
       if(!response) {
         throw e;
@@ -93,7 +92,8 @@ console.log(e);
       };
       // errors in the 400 range can have response.data
       if(response.status >= 400 && response.status < 500) {
-        error.details.error = response.data || e;
+        // httpClient puts the data on the error object
+        error.details.error = e.data || response.data || e;
       }
       throw error;
     }
@@ -134,7 +134,7 @@ console.log(e);
     try {
       const response = await httpClient.get('', {
         prefixUrl: baseURL,
-        httpsAgent: this.httpsAgent,
+        agent: this.httpsAgent,
         timeout: this.timeout,
         headers: {...DEFAULT_HEADERS, ...headers}
       });
@@ -154,7 +154,8 @@ console.log(e);
       // if we get an error in the 400 range add the response.data
       // to the error if present
       if(response.status >= 400 && response.status < 500) {
-        error.details.error = response.data || e;
+        // httpClient puts the data on the error object
+        error.details.error = e.data || response.data || e;
       }
       throw error;
     }
@@ -248,34 +249,36 @@ console.log(e);
    * @returns {Promise<Object>} The result of the send.
    */
   async sendDocument({document, service, headers = {}}) {
-    const requestHeaders = Object.assign(
-      {}, constants.DEFAULT_HEADERS, headers);
     if(!this.ledgerAgent) {
       await this.getAgent();
     }
     const baseURL = this.ledgerAgent.service[service];
-    const serviceApi =
-      create({baseURL, httpsAgent: this.httpsAgent, timeout: this.timeout});
-    const response = await serviceApi.post('/', document, {
-      headers: requestHeaders
-    });
-    if(response.problem) {
+    try {
+      const response = await httpClient.post('', {
+        prefixUrl: baseURL,
+        agent: this.httpsAgent,
+        timeout: this.timeout,
+        json: document,
+        headers: {...DEFAULT_HEADERS, ...headers}
+      });
+      return response.data;
+    } catch(e) {
+      const {response} = e;
+      if(!response) {
+        throw e;
+      }
       const error = new WebLedgerClientError(
         'Error sending document.', 'NetworkError',
         {baseURL, service, document});
-      if(response.problem === 'CLIENT_ERROR') {
-        error.details = {
-          baseURL, document, service, error: response.data,
-          status: response.status
-        };
-      } else {
-        error.details = {
-          baseURL, document, service, error: response.originalError
-        };
+      error.details = {
+        baseURL, document, service, error: e
+      };
+      if(response.status >= 400 && response.status < 500) {
+        error.details.status = response.status;
+        error.details.error = e.data || response.data || e;
       }
       throw error;
     }
-    return response.data;
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
   "dependencies": {
+    "@digitalbazaar/http-client": "^1.1.0",
     "apisauce": "^2.0.1",
     "lodash.get": "^4.4.2"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "@digitalbazaar/http-client": "^1.1.0",
-    "apisauce": "^2.0.1",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-jsdoc": "^4.6.0",
     "jsdoc-to-markdown": "^6.0.1",
     "mocha": "^8.2.1",
-    "nock": "^10.0.2",
+    "nock": "^13.1.0",
     "nyc": "^15.1.0",
     "sinon": "^7.1.1",
     "sinon-chai": "^3.2.0"

--- a/tests/web-ledger-client.spec.js
+++ b/tests/web-ledger-client.spec.js
@@ -217,7 +217,7 @@ describe('web ledger client', () => {
         const {ledgerAgent: [{service: {ledgerOperationService}}]} =
           LEDGER_AGENTS_DOC;
         nock(ledgerOperationService)
-          .post('/')
+          .post('')
           .reply(201);
 
         _nockLedgerAgentStatus();
@@ -244,7 +244,7 @@ describe('web ledger client', () => {
         const {ledgerAgent: [{service: {ledgerOperationService}}]} =
           LEDGER_AGENTS_DOC;
         nock(ledgerOperationService)
-          .post('/')
+          .post('')
           .reply(404);
         const record = {id: 'https://example.com/foo'};
         const operation = await client.wrap({record});
@@ -271,7 +271,7 @@ describe('web ledger client', () => {
           LEDGER_AGENTS_DOC;
         const reply = {helpful: 'information'};
         nock(ledgerOperationService)
-          .post('/')
+          .post('')
           .reply(400, reply);
         const record = {id: 'https://example.com/foo'};
         const operation = await client.wrap({record});
@@ -351,6 +351,6 @@ function _nockLedgerAgentStatus({removeTargetNode = false} = {}) {
     delete ledgerAgentStatus.targetNode;
   }
   nock(ledgerAgentStatusService)
-    .get('/')
+    .get('')
     .reply(200, ledgerAgentStatus, jsonldHeaders);
 }

--- a/tests/web-ledger-client.spec.js
+++ b/tests/web-ledger-client.spec.js
@@ -17,6 +17,10 @@ const TEST_DID = TEST_DID_RESULT.record.id;
 const LEDGER_AGENTS_DOC = require('./dids/ledger-agents.json');
 const LEDGER_AGENT_STATUS = require('./dids/ledger-agent-status.json');
 
+const jsonldHeaders = {
+  'content-type': 'application/ld+json, application/json'
+};
+
 describe('web ledger client', () => {
   let client;
 
@@ -146,7 +150,7 @@ describe('web ledger client', () => {
         nock('https://genesis.testnet.veres.one')
           .post('/ledger-agents/72fdcd6a-5861-4307-ba3d-cbb72509533c' +
                '/query/?id=' + encodeURIComponent(TEST_DID))
-          .reply(200, TEST_DID_RESULT);
+          .reply(200, TEST_DID_RESULT, jsonldHeaders);
 
         _nockLedgerAgentStatus();
 
@@ -348,5 +352,5 @@ function _nockLedgerAgentStatus({removeTargetNode = false} = {}) {
   }
   nock(ledgerAgentStatusService)
     .get('/')
-    .reply(200, ledgerAgentStatus);
+    .reply(200, ledgerAgentStatus, jsonldHeaders);
 }

--- a/tests/web-ledger-client.spec.js
+++ b/tests/web-ledger-client.spec.js
@@ -149,7 +149,7 @@ describe('web ledger client', () => {
 
         nock('https://genesis.testnet.veres.one')
           .post('/ledger-agents/72fdcd6a-5861-4307-ba3d-cbb72509533c' +
-               '/query/?id=' + encodeURIComponent(TEST_DID))
+               '/query?id=' + encodeURIComponent(TEST_DID))
           .reply(200, TEST_DID_RESULT, jsonldHeaders);
 
         _nockLedgerAgentStatus();
@@ -165,7 +165,7 @@ describe('web ledger client', () => {
 
         nock('https://genesis.testnet.veres.one')
           .post('/ledger-agents/72fdcd6a-5861-4307-ba3d-cbb72509533c' +
-               '/query/?id=' + encodeURIComponent(TEST_DID))
+               '/query?id=' + encodeURIComponent(TEST_DID))
           .reply(404);
 
         _nockLedgerAgentStatus();
@@ -189,7 +189,7 @@ describe('web ledger client', () => {
         const reply = {helpful: 'information'};
         nock('https://genesis.testnet.veres.one')
           .post('/ledger-agents/72fdcd6a-5861-4307-ba3d-cbb72509533c' +
-               '/query/?id=' + encodeURIComponent(TEST_DID))
+               '/query?id=' + encodeURIComponent(TEST_DID))
           .reply(400, reply);
 
         _nockLedgerAgentStatus();


### PR DESCRIPTION
My apologies about how long this has taken, but there were a few interesting things that came up during this PR.

1. when nock returns a 400 http response `@digitalbazaar/http-client` adds the resulting data to the `error` object and not the `error.response` object. (this is probably the case with real requests too)
2. When sending to the `ledgerQueryService` we were using the form `query/?id='foo'` this is fine as express treats that url as equivalent to `query?id=foo`, but I changed the tests and the path to match the documented route in [`bedrock-ledger-agent`](https://github.com/digitalbazaar/bedrock-ledger-agent/blob/453e2c6fa195ad5b5c81aaa015681c4b09f7f629/lib/http.js#L440-L444) 
3. `bedrock-ledger-agent` already does end tests using the form `query?id='foo'` I tested it with `/?id` and without and it worked with either path.
4. jsonld headers were added to tests that return jsonld
5. nock was upgraded so that when using reply it will set a content-type from the response body if no content-type is provided.