### PR TITLE
Change voters to peers in test data.

### DIFF
--- a/tests/dids/ledger-agent-status.json
+++ b/tests/dids/ledger-agent-status.json
@@ -54,5 +54,5 @@
       "id": "https://genesis.testnet.veres.one/ledger-agents/72fdcd6a-5861-4307-ba3d-cbb72509533c/plugins/veres-one-ticket-service-agent"
     }
   },
-  "targetNode": "https://genesis.testnet.veres.one/consensus/continuity2017/voters/z6Mkr6HD7yRn6BtRE2HGFcfzWf25ce9p4nSSWZkVXfQekAoX"
+  "targetNode": "https://genesis.testnet.veres.one/consensus/continuity2017/peers/z6Mkr6HD7yRn6BtRE2HGFcfzWf25ce9p4nSSWZkVXfQekAoX"
 }


### PR DESCRIPTION
This PR is pretty small, but is primarily here so that test does not get out of sync with the routes the ledger uses.

Related: https://github.com/digitalbazaar/bedrock-ledger-consensus-continuity/pull/259